### PR TITLE
CSS Fix for blinking text and images in Chrome and Safari

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,7 +5,8 @@
  | Here are slider styles
  | 
 */
-
+// This is to prevent the images and text to blink in chrome and safari.
+body{-webkit-transform: translateZ(0);}
 .slider {
 	position: relative;
 	width: 100%;


### PR DESCRIPTION
On every image transition in the slider, text and images else where were blinking.
