### PR TITLE
Fix for makig sure there is a _.navWrapper in the slide method

### DIFF
--- a/jquery.glide.js
+++ b/jquery.glide.js
@@ -464,7 +464,7 @@
 		}
 
 		// Set to navigation item current class
-		if (_.options.nav) {
+		if (_.options.nav && _.navWrapper) {
 			_.navWrapper.children()
 				.eq(-currentSlide)
 					.addClass(navCurrentClass)


### PR DESCRIPTION
When resizing the browser window and nav is set tot true and there is only one image in the slider, the _.navWrapper is undefined in the slide method.
