### PR TITLE
Transition transforms only

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,11 +30,11 @@
 		 * Here is CSS transitions 
 		 * responsible for slider animation in modern broswers
 		 */
-		-webkit-transition: all 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000); 
-		   -moz-transition: all 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000); 
-		    -ms-transition: all 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000); 
-		     -o-transition: all 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000); 
-		        transition: all 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000);
+		-webkit-transition: -webkit-transform 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000); 
+		   -moz-transition: -moz-transform 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000); 
+		    -ms-transition: -ms-transform 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000); 
+		     -o-transition: -o-transform 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000); 
+		        transition: transform 500ms cubic-bezier(0.165, 0.840, 0.440, 1.000);
 	}
 	
 		.slide {


### PR DESCRIPTION
This fixes an issue where the height of the sliding element would also transition, allowing the next slide to briefly appear beneath it, when resizing the browser window.
