### PR TITLE
Fixed issue where page would infinite loop if there were no slides on the page

### DIFF
--- a/src/components/clones.js
+++ b/src/components/clones.js
@@ -23,21 +23,19 @@ export default function (Glide, Components, Events) {
       let perView = Glide.settings.perView
       let length = Components.Html.slides.length
 
-      if (length === 0) {
-        return pattern;
-      }
+      if (length !== 0) {
+        // Repeat creating pattern based on the ratio calculated
+        // by number in `perView` per actual number of slides.
+        for (let r = 0; r < Math.max(1, Math.floor(perView / length)); r++) {
+          // Fill pattern with indexes of slides at the beginning of track.
+          for (let i = 0; i <= length - 1; i++) {
+            pattern.push(`${i}`)
+          }
 
-      // Repeat creating pattern based on the ratio calculated
-      // by number in `perView` per actual number of slides.
-      for (let r = 0; r < Math.max(1, Math.floor(perView / length)); r++) {
-        // Fill pattern with indexes of slides at the beginning of track.
-        for (let i = 0; i <= length - 1; i++) {
-          pattern.push(`${i}`)
-        }
-
-        // Fill pattern with indexes of slides from the end of track.
-        for (let i = length - 1; i >= 0; i--) {
-          pattern.unshift(`-${i}`)
+          // Fill pattern with indexes of slides from the end of track.
+          for (let i = length - 1; i >= 0; i--) {
+            pattern.unshift(`-${i}`)
+          }
         }
       }
 

--- a/src/components/clones.js
+++ b/src/components/clones.js
@@ -23,8 +23,9 @@ export default function (Glide, Components, Events) {
       let perView = Glide.settings.perView
       let length = Components.Html.slides.length
 
-      if (length === 0)
-      	return pattern;
+      if (length === 0) {
+        return pattern;
+      }
 
       // Repeat creating pattern based on the ratio calculated
       // by number in `perView` per actual number of slides.

--- a/src/components/clones.js
+++ b/src/components/clones.js
@@ -23,6 +23,9 @@ export default function (Glide, Components, Events) {
       let perView = Glide.settings.perView
       let length = Components.Html.slides.length
 
+      if (length === 0)
+      	return pattern;
+
       // Repeat creating pattern based on the ratio calculated
       // by number in `perView` per actual number of slides.
       for (let r = 0; r < Math.max(1, Math.floor(perView / length)); r++) {


### PR DESCRIPTION
Noticed that that the following line in `clones.js` would divide by 0 and create an infinite loop that would choke webpages if there were no slides currently on the page:

```javascript
for (let r = 0; r < Math.max(1, Math.floor(perView / length)); r++) {
  // ...
}
```

This fix just returns the `pattern` argument if `length == 0` (see [here](https://github.com/glidejs/glide/blob/master/src/components/clones.js#L22) for context).