### PR TITLE
Don't use initial for css

### DIFF
--- a/src/assets/sass/glide.core.scss
+++ b/src/assets/sass/glide.core.scss
@@ -41,7 +41,7 @@
     width: 100%;
     height: 100%;
     flex-shrink: 0;
-    white-space: initial;
+    white-space: normal;
     user-select: none;
     -webkit-touch-callout: none;
     -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
`initial` is not supported in IE, so texts in my glide slides were not wrapping properly. lib says IE11+, so PR. let me know if you need anything else to support this PR.

https://developer.mozilla.org/en-US/docs/Web/CSS/initial