### PR TITLE
fix run length calculation

### DIFF
--- a/src/components/run.js
+++ b/src/components/run.js
@@ -163,7 +163,7 @@ export default function (Glide, Components, Events) {
       // While number of slides inside instance is smaller
       // that `perView` settings we should't run at all.
       // Running distance has to be zero.
-      if (settings.perView > length) {
+      if (settings.focusAt !== 'center' && settings.perView > length) {
         return 0
       }
 

--- a/src/components/run.js
+++ b/src/components/run.js
@@ -160,13 +160,6 @@ export default function (Glide, Components, Events) {
       let { settings } = Glide
       let { length } = Components.Html.slides
 
-      // While number of slides inside instance is smaller
-      // that `perView` settings we should't run at all.
-      // Running distance has to be zero.
-      if (settings.focusAt !== 'center' && settings.perView > length) {
-        return 0
-      }
-
       // If the `bound` option is acitve, a maximum running distance should be
       // reduced by `perView` and `focusAt` settings. Running distance
       // should end before creating an empty space after instance.


### PR DESCRIPTION
when center mode is active, some slides might not be in the view, so we have to allow running

Fixes: #292 