### PR TITLE
fix(run): run.start and run.end events should be called properly

### DIFF
--- a/src/components/run.js
+++ b/src/components/run.js
@@ -30,6 +30,14 @@ export default function (Glide, Components, Events) {
         Events.emit('run', this.move)
 
         Components.Transition.after(() => {
+          if (this.isStart()) {
+            Events.emit('run.start', this.move)
+          }
+
+          if (this.isEnd()) {
+            Events.emit('run.end', this.move)
+          }
+
           if (this.isOffset('<') || this.isOffset('>')) {
             this._o = false
 
@@ -64,8 +72,6 @@ export default function (Glide, Components, Events) {
 
               Glide.index = 0
             }
-
-            Events.emit('run.end', move)
           } else if (countableSteps) {
             Glide.index += Math.min(length - Glide.index, -toInt(steps))
           } else {
@@ -82,8 +88,6 @@ export default function (Glide, Components, Events) {
 
               Glide.index = length
             }
-
-            Events.emit('run.start', move)
           } else if (countableSteps) {
             Glide.index -= Math.min(Glide.index, toInt(steps))
           } else {
@@ -142,9 +146,11 @@ export default function (Glide, Components, Events) {
      * @returns {Object}
      */
     set (value) {
+      let step = value.substr(1)
+
       this._m = {
         direction: value.substr(0, 1),
-        steps: value.substr(1) ? value.substr(1) : 0
+        steps: step ? (toInt(step) ? toInt(step) : step) : 0
       }
     }
   })

--- a/tests/fixtures/transition.js
+++ b/tests/fixtures/transition.js
@@ -3,3 +3,7 @@ import defaults from '../../src/defaults'
 export function afterTransition (callback) {
   setTimeout(callback, defaults.animationDuration + 10)
 }
+
+export function afterRewindTransition (callback) {
+  setTimeout(callback, defaults.rewindDuration + 10)
+}

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -191,4 +191,39 @@ describe("Event's callbacks on", () => {
       done()
     })
   })
+
+  test('`translate.jump` should be called when making a loop change', (done) => {
+    const glide = new Glide('#glide', { type: 'carousel' })
+
+    let jumpCallback = jest.fn()
+
+    glide.on('translate.jump', jumpCallback)
+
+    glide.mount().go('<')
+
+    expect(jumpCallback).not.toBeCalled()
+    afterTransition(() => {
+      expect(jumpCallback).toBeCalled()
+
+      done()
+    })
+  })
+
+  test('`translate.jump` should be called when making a loop change', (done) => {
+    const { slides } = query(document)
+    const glide = new Glide('#glide', { type: 'carousel', startAt: slides.length - 1 })
+
+    let jumpCallback = jest.fn()
+
+    glide.on('translate.jump', jumpCallback)
+
+    glide.mount().go('>')
+
+    expect(jumpCallback).not.toBeCalled()
+    afterTransition(() => {
+      expect(jumpCallback).toBeCalled()
+
+      done()
+    })
+  })
 })

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1,17 +1,17 @@
 import html from '../fixtures/html'
+import { query } from '../fixtures/query'
+import { afterTransition, afterRewindTransition } from '../fixtures/transition'
 
 import Glide from '../../entry/entry-complete'
 
-describe('Events on', () => {
-  let glide = null
-
+describe("Event's callbacks on", () => {
   beforeEach(() => {
     document.body.innerHTML = html
-
-    glide = new Glide('#glide')
   })
 
-  test('mounting should be called', () => {
+  test('`mount.*` should be called', () => {
+    const glide = new Glide('#glide')
+
     let beforeCallback = jest.fn()
     let afterCallback = jest.fn()
 
@@ -24,7 +24,45 @@ describe('Events on', () => {
     expect(afterCallback).toHaveBeenCalled()
   })
 
-  test('building should be called', () => {
+  test('`update` should be called', () => {
+    const glide = new Glide('#glide')
+
+    let updateCallback = jest.fn()
+
+    glide.on('update', updateCallback)
+
+    glide.mount().update()
+
+    expect(updateCallback).toHaveBeenCalled()
+  })
+
+  test('`play` should be called', () => {
+    const glide = new Glide('#glide')
+
+    let playCallback = jest.fn()
+
+    glide.on('play', playCallback)
+
+    glide.mount().play()
+
+    expect(playCallback).toHaveBeenCalled()
+  })
+
+  test('`pause` should be called', () => {
+    const glide = new Glide('#glide')
+
+    let pauseCallback = jest.fn()
+
+    glide.on('pause', pauseCallback)
+
+    glide.mount().pause()
+
+    expect(pauseCallback).toHaveBeenCalled()
+  })
+
+  test('`build.*` should be called', () => {
+    const glide = new Glide('#glide')
+
     let beforeCallback = jest.fn()
     let afterCallback = jest.fn()
 
@@ -35,5 +73,122 @@ describe('Events on', () => {
 
     expect(beforeCallback).toHaveBeenCalled()
     expect(afterCallback).toHaveBeenCalled()
+  })
+
+  test('`run` should be called with `move` parameter', () => {
+    const glide = new Glide('#glide')
+
+    let move = { direction: '=', steps: 1 }
+    let runCallback = jest.fn()
+
+    glide.on('run', runCallback)
+
+    glide.mount().go('=1')
+
+    expect(runCallback).toBeCalledWith(move)
+  })
+
+  test('`run.before` should be called with `move` parameter', () => {
+    const glide = new Glide('#glide')
+
+    let move = { direction: '=', steps: 1 }
+    let beforeCallback = jest.fn()
+
+    glide.on('run.before', beforeCallback)
+
+    glide.mount().go('=1')
+
+    expect(beforeCallback).toBeCalledWith(move)
+  })
+
+  test('`run.after` should be called with `move` parameter', (done) => {
+    const glide = new Glide('#glide')
+
+    let move = { direction: '=', steps: 1 }
+    let afterCallback = jest.fn()
+
+    glide.on('run.after', afterCallback)
+
+    glide.mount().go('=1')
+
+    expect(afterCallback).not.toBeCalled()
+    afterTransition(() => {
+      expect(afterCallback).toBeCalledWith(move)
+
+      done()
+    })
+  })
+
+  test('`run.offset` should be called with `move` parameter when changing slide from first to the last one', (done) => {
+    const glide = new Glide('#glide', { startAt: 0 })
+
+    let move = { direction: '<', steps: 0 }
+    let offsetCallback = jest.fn()
+
+    glide.on('run.offset', offsetCallback)
+
+    glide.mount().go('<')
+
+    expect(offsetCallback).not.toBeCalled()
+    afterRewindTransition(() => {
+      expect(offsetCallback).toBeCalledWith(move)
+
+      done()
+    })
+  })
+
+  test('`run.offset` should be called with `move` parameter when changing slide from last to the first one', (done) => {
+    const { slides } = query(document)
+    const glide = new Glide('#glide', { startAt: slides.length - 1 })
+
+    let move = { direction: '>', steps: 0 }
+    let offsetCallback = jest.fn()
+
+    glide.on('run.offset', offsetCallback)
+
+    glide.mount().go('>')
+
+    expect(offsetCallback).not.toBeCalled()
+    afterRewindTransition(() => {
+      expect(offsetCallback).toBeCalledWith(move)
+
+      done()
+    })
+  })
+
+  test('`run.start` should be called with `move` parameter when changing to the first slide', (done) => {
+    const glide = new Glide('#glide', { startAt: 1 })
+
+    let move = { direction: '<', steps: '<' }
+    let startCallback = jest.fn()
+
+    glide.on('run.start', startCallback)
+
+    glide.mount().go('<<')
+
+    expect(startCallback).not.toBeCalled()
+    afterTransition(() => {
+      expect(startCallback).toBeCalledWith(move)
+
+      done()
+    })
+  })
+
+  test('`run.end` should be called with `move` parameter when changing to the first slide', (done) => {
+    const glide = new Glide('#glide', { startAt: 1 })
+
+    let move = { direction: '>', steps: '>' }
+    let endCallback = jest.fn()
+
+    glide.on('run.end', endCallback)
+
+    glide.mount().go('>>')
+
+    expect(endCallback).not.toBeCalled()
+    afterTransition(() => {
+      expect(endCallback).toBeCalledWith(move)
+
+      done()
+    })
   })
 })


### PR DESCRIPTION
- [ ] `run.start` and `run.end` events should be called when moving to first/last silde
- [ ] Introduce tests for events