### PR TITLE
Carousel without rewind

### DIFF
--- a/src/components/run.js
+++ b/src/components/run.js
@@ -68,7 +68,7 @@ export default function (Glide, Components, Events) {
           if (steps === '>') {
             Glide.index = length
           } else if (this.isEnd()) {
-            if (!(Glide.isType('slider') && !Glide.settings.rewind)) {
+            if (Glide.isType('slider') && Glide.settings.rewind) {
               this._o = true
 
               Glide.index = 0
@@ -84,7 +84,7 @@ export default function (Glide, Components, Events) {
           if (steps === '<') {
             Glide.index = 0
           } else if (this.isStart()) {
-            if (!(Glide.isType('slider') && !Glide.settings.rewind)) {
+            if (Glide.isType('slider') && Glide.settings.rewind) {
               this._o = true
 
               Glide.index = length

--- a/tests/functional/carousel.test.js
+++ b/tests/functional/carousel.test.js
@@ -16,7 +16,7 @@ describe('Glide initialized as `carousel`', () => {
     expect(glide.isType('carousel')).toBe(true)
   })
 
-  test('should go to the last slide when we are on the first slide and moving backward', (done) => {
+  test('should not go to the last slide when we are on the first slide and moving backward', (done) => {
     let { slides } = query(document)
 
     let glide = new Glide('#glide', {
@@ -27,14 +27,14 @@ describe('Glide initialized as `carousel`', () => {
     glide.go('<')
 
     afterTransition(() => {
-      expect(slides[0].classList.contains(defaults.classes.activeSlide)).toBe(false)
-      expect(slides[slides.length - 1].classList.contains(defaults.classes.activeSlide)).toBe(true)
+      expect(slides[0].classList.contains(defaults.classes.activeSlide)).toBe(true)
+      expect(slides[slides.length - 1].classList.contains(defaults.classes.activeSlide)).toBe(false)
 
       done()
     })
   })
 
-  test('should go to the first slide when we are on the last slide and moving forward', (done) => {
+  test('should not go to the first slide when we are on the last slide and moving forward', (done) => {
     let { slides } = query(document)
 
     let glide = new Glide('#glide', {
@@ -45,8 +45,8 @@ describe('Glide initialized as `carousel`', () => {
     glide.go('>')
 
     afterTransition(() => {
-      expect(slides[slides.length - 1].classList.contains(defaults.classes.activeSlide)).toBe(false)
-      expect(slides[0].classList.contains(defaults.classes.activeSlide)).toBe(true)
+      expect(slides[slides.length - 1].classList.contains(defaults.classes.activeSlide)).toBe(true)
+      expect(slides[0].classList.contains(defaults.classes.activeSlide)).toBe(false)
 
       done()
     })

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -192,7 +192,7 @@ describe("Event's callbacks on", () => {
     })
   })
 
-  test('`translate.jump` should be called when making a loop change', (done) => {
+  test('`translate.jump` should not be called when making a loop change', (done) => {
     const glide = new Glide('#glide', { type: 'carousel' })
 
     let jumpCallback = jest.fn()
@@ -203,13 +203,13 @@ describe("Event's callbacks on", () => {
 
     expect(jumpCallback).not.toBeCalled()
     afterTransition(() => {
-      expect(jumpCallback).toBeCalled()
+      expect(jumpCallback).not.toBeCalled()
 
       done()
     })
   })
 
-  test('`translate.jump` should be called when making a loop change', (done) => {
+  test('`translate.jump` should not be called when making a loop change', (done) => {
     const { slides } = query(document)
     const glide = new Glide('#glide', { type: 'carousel', startAt: slides.length - 1 })
 
@@ -221,7 +221,7 @@ describe("Event's callbacks on", () => {
 
     expect(jumpCallback).not.toBeCalled()
     afterTransition(() => {
-      expect(jumpCallback).toBeCalled()
+      expect(jumpCallback).not.toBeCalled()
 
       done()
     })


### PR DESCRIPTION
When using Glide I wanted to use the type `carousel` to prevent rewind by default, as stated by the [documentation](https://glidejs.com/docs/options/#type), but it wasn't working. Only the type `slider` allowed for custom rewind behaviour, as expected, but it made the `carousel` type irrelevant.

This PR corrects the conditions for the rewind, as well as the tests associated to it.