### PR TITLE
Set margin: 0 for .glide__slides

### DIFF
--- a/src/assets/sass/glide.core.scss
+++ b/src/assets/sass/glide.core.scss
@@ -26,6 +26,7 @@
     transform-style: preserve-3d;
     touch-action: pan-Y;
     overflow: hidden;
+    margin: 0;
     padding: 0;
     white-space: nowrap;
     display: flex;


### PR DESCRIPTION
In some apps `margin` can be more than `0` for `ul` which will lead to displaced slides.

This PR will prevent that.