### PR TITLE
fix: on(eventName, handler).remove() - remove() not working

### DIFF
--- a/src/core/event/events-bus-subscription.js
+++ b/src/core/event/events-bus-subscription.js
@@ -1,0 +1,17 @@
+/**
+ * Construct a EventBus instance.
+ *
+ * @param {EventsBus} eventsBus
+ * @param {String|Array} event
+ * @param {Function} handler
+ */
+export default function EventsBusSubscription (eventsBus, event, handler) {
+  return {
+    /**
+     * Removes handler from event
+     */
+    remove: () => {
+      eventsBus.off(event, handler)
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,7 @@ export default class Glide {
   }
 
   /**
-   * Adds cuutom event listener with handler.
+   * Adds custom event listener with handler.
    *
    * @param  {String|Array} event
    * @param  {Function} handler

--- a/src/utils/unit.js
+++ b/src/utils/unit.js
@@ -83,3 +83,17 @@ export function isUndefined (value) {
 export function isArray (value) {
   return value.constructor === Array
 }
+
+/**
+ * Invokes method for each event
+ *
+ * @param {Object} context
+ * @param {string} method
+ * @param {string[]} events
+ * @param {Function|Object=} arg
+ */
+export function invokeEach (context, method, events, arg) {
+  for (let i = 0; i < events.length; i++) {
+    context[method](events[i], arg)
+  }
+}

--- a/tests/functional/events-bus.test.js
+++ b/tests/functional/events-bus.test.js
@@ -1,0 +1,111 @@
+import EventsBus from '../../src/core/event/events-bus'
+
+describe('EventsBus', () => {
+  describe('eventName is string', () => {
+    let bus
+    let events
+    let handler
+    const eventName = 'foo'
+
+    beforeEach(() => {
+      handler = jest.fn()
+      bus = new EventsBus(events = {})
+    })
+
+    test('`.on` should save handler in events object', () => {
+      bus.on(eventName, handler)
+
+      expect(events).toEqual({
+        [eventName]: [handler]
+      })
+    })
+
+    test('`.emit` should emit into handlers', () => {
+      bus.on(eventName, handler)
+      bus.emit(eventName, 'value')
+
+      expect(handler).toHaveBeenCalledWith('value')
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    test('`.off()` should remove event from events', () => {
+      bus.on(eventName, handler)
+      bus.off(eventName, handler)
+
+      bus.emit(eventName, 'value')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    test('`.on().remove()` should remove event from events', () => {
+      bus.on(eventName, handler).remove()
+
+      bus.emit(eventName, 'value')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    test('`.emit` should not throw if a listener was removed', () => {
+      const handler2 = jest.fn()
+      const handler3 = jest.fn()
+
+      bus.on(eventName, handler2)
+      bus.on(eventName, handler)
+      bus.on(eventName, handler3)
+
+      bus.off(eventName, handler2)
+      bus.off(eventName, handler3)
+
+      bus.emit(eventName, 'value')
+      expect(handler).toHaveBeenCalledWith('value')
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('eventName is string[]', () => {
+    let bus
+    let events
+    let handler
+    const eventName = ['foo', 'bar']
+
+    beforeEach(() => {
+      handler = jest.fn()
+      bus = new EventsBus(events = {})
+    })
+
+    test('`.on` should save handler in events object', () => {
+      bus.on(eventName, handler)
+
+      expect(events).toEqual({
+        [eventName[0]]: [handler],
+        [eventName[1]]: [handler]
+      })
+    })
+
+    test('`.emit` should emit into handlers', () => {
+      bus.on(eventName, handler)
+      bus.emit(eventName, 'value')
+
+      expect(handler).toHaveBeenCalledWith('value')
+      expect(handler).toHaveBeenCalledTimes(2)
+    })
+
+    test('`.off()` should remove the handler', () => {
+      bus.on(eventName, handler)
+      bus.off(eventName, handler)
+
+      bus.emit(eventName, 'value')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    test('`.on().remove()` should remove event from events', () => {
+      bus.on(eventName, handler).remove()
+
+      expect(events).toEqual({
+        [eventName[0]]: [],
+        [eventName[1]]: []
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add possibility to remove an event handler. The `remove` method that `on` returns:

![image](https://user-images.githubusercontent.com/905328/60099200-7c9b1d00-9757-11e9-9dc0-b34590dfd16a.png)

`this` inside `remove` is not scoped, and thus the method throws. And if it worked, just deleting the index would result in `emit` then throwing. And if you give `on` an array of events, the remove method isn't even returned.

This PR fixes all of this.

* `on('foo', () => console.log()).remove()` works
* `on(['foo', 'bar'], () => console.log()).remove()` works

Tried to not hurt lib size with this PR. Increases `glide.min.js` build by 157 bytes