### PR TITLE
fix: Recollect slides during update to support dynamic additions, removals and reordering

### DIFF
--- a/src/components/html.js
+++ b/src/components/html.js
@@ -5,7 +5,7 @@ import { isString } from '../utils/unit'
 
 const TRACK_SELECTOR = '[data-glide-el="track"]'
 
-export default function (Glide, Components) {
+export default function (Glide, Components, Events) {
   const Html = {
     /**
      * Setup slider HTML nodes.
@@ -15,6 +15,13 @@ export default function (Glide, Components) {
     mount () {
       this.root = Glide.selector
       this.track = this.root.querySelector(TRACK_SELECTOR)
+      this.collectSlides()
+    },
+
+    /**
+     * Collect slides
+     */
+    collectSlides () {
       this.slides = Array.prototype.slice.call(this.wrapper.children).filter((slide) => {
         return !slide.classList.contains(Glide.settings.classes.slide.clone)
       })
@@ -82,6 +89,13 @@ export default function (Glide, Components) {
     get () {
       return Html.track.children[0]
     }
+  })
+
+  /**
+   * Add/remove/reorder dynamic slides
+   */
+  Events.on('update', () => {
+    Html.collectSlides()
   })
 
   return Html

--- a/tests/functional/update.test.js
+++ b/tests/functional/update.test.js
@@ -33,4 +33,18 @@ describe('Calling `update()` method with', () => {
     expect(glide.index).toBe(1)
     expect(slides[1].classList.contains(defaults.classes.slide.active)).toBe(true)
   })
+
+  test('additional slide should be updated', () => {
+    let { wrapper } = query(document)
+    let newSlide = document.createElement('li')
+    newSlide.className = 'glide__slide'
+    newSlide.innerHTML = 0
+
+    let glide = new Glide('#glide', { startAt: 0 }).mount()
+
+    wrapper.append(newSlide)
+    glide.update()
+
+    expect(newSlide.style.width).toBeTruthy()
+  })
 })


### PR DESCRIPTION
Currently, if you add new slides or remove slides, and then call update(), carousel will completely break with strange behaviour. This is because the Components.Html.slides property still contains removed slides, and does not contain new slides. This means clones can get added into the wrong place (if the initial slide or last slide was moved for example) and also means clones are incorrect. Furthermore, new slides don't receive a width style so display completely the wrong size.

This PR implements updating of slides during `update()`, and thus the Sizes and Clones components now work correctly after new slides are added, old slides are removed or existing slides are moved.

I have also implemented a functional test for this, which fails when the Html component changes are reverted. It checks that the width style is properly applied to a new dynamically added slide.

This PR will allow Glide to be safely used in a React environment. One just needs to call `update()` during `componentDidUpdate` either every time or when slides are known to have been changed. Using hooks this is even easier by calling `update()` in a `useEffect()`, with dependencies on any props that affect slides.

Related issues:
* #443 
* #453
* #364 
* #71 (OP was not having this problem, but comments after closure refer to dynamic addition issues)
* #77