### PR TITLE
Add .glide__bullet:focus.glide__bullet--active:focus state

### DIFF
--- a/dist/css/glide.theme.css
+++ b/dist/css/glide.theme.css
@@ -55,6 +55,10 @@
     background-color: rgba(255, 255, 255, 0.5); }
   .glide__bullet--active {
     background-color: white; }
+.glide__bullet:focus.glide__bullet--active:focus {
+    border: 2px solid white;
+    background-color: white;
+}
 
 .glide--swipeable {
   cursor: grab;


### PR DESCRIPTION
In Chrome you need to a have separate state for a bullet that's both active and focused.