### PR TITLE
Fix for browser prefixing transform on old but supported browsers

### DIFF
--- a/src/components/translate.js
+++ b/src/components/translate.js
@@ -10,8 +10,11 @@ export default function (Glide, Components, Events) {
      */
     set (value) {
       let transform = mutator(Glide, Components).mutate(value)
+      const translate3d = `translate3d(${-1 * transform}px, 0px, 0px)`
 
-      Components.Html.wrapper.style.transform = `translate3d(${-1 * transform}px, 0px, 0px)`
+      Components.Html.wrapper.style.mozTransform = translate3d; // needed for supported Firefox 10-15
+      Components.Html.wrapper.style.webkitTransform = translate3d; // needed for supported Chrome 10-35, Safari 5.1-8, and Opera 15-22
+      Components.Html.wrapper.style.transform = translate3d
     },
 
     /**

--- a/src/components/translate.js
+++ b/src/components/translate.js
@@ -12,8 +12,8 @@ export default function (Glide, Components, Events) {
       let transform = mutator(Glide, Components).mutate(value)
       const translate3d = `translate3d(${-1 * transform}px, 0px, 0px)`
 
-      Components.Html.wrapper.style.mozTransform = translate3d; // needed for supported Firefox 10-15
-      Components.Html.wrapper.style.webkitTransform = translate3d; // needed for supported Chrome 10-35, Safari 5.1-8, and Opera 15-22
+      Components.Html.wrapper.style.mozTransform = translate3d // needed for supported Firefox 10-15
+      Components.Html.wrapper.style.webkitTransform = translate3d // needed for supported Chrome 10-35, Safari 5.1-8, and Opera 15-22
       Components.Html.wrapper.style.transform = translate3d
     },
 


### PR DESCRIPTION
Was testing Glide on browsers that are listed as supported on https://github.com/glidejs/glide#browser-support, but ended up needing this change to actually have the slider / carousel move since some of these legacy browsers don't support un-prefixed transforms.