### PR TITLE
Optional peek distance values

### DIFF
--- a/src/utils/unit.js
+++ b/src/utils/unit.js
@@ -6,7 +6,7 @@
  * @returns {Number}
  */
 export function toInt (value) {
-  return parseInt(value)
+  return parseInt(value) || 0
 }
 
 /**
@@ -17,7 +17,7 @@ export function toInt (value) {
  * @returns {Number}
  */
 export function toFloat (value) {
-  return parseFloat(value)
+  return parseFloat(value) || 0
 }
 
 /**
@@ -40,7 +40,6 @@ export function isString (value) {
  */
 export function isObject (value) {
   let type = typeof value
-
   return type === 'function' || type === 'object' && !!value // eslint-disable-line no-mixed-operators
 }
 

--- a/tests/unit/unit.test.js
+++ b/tests/unit/unit.test.js
@@ -9,10 +9,11 @@ import {
 } from '../../src/utils/unit'
 
 describe('Function', () => {
-  test('`toInt` should covert entered value in various formats to actual width number', () => {
-    expect(toInt(1, 100)).toBe(1)
-    expect(toInt('1', 100)).toBe(1)
-    expect(toInt('1px', 100)).toBe(1)
+  test('`toInt` should covert entered value in various formats to actual number', () => {
+    expect(toInt(1)).toBe(1)
+    expect(toInt('1')).toBe(1)
+    expect(toInt('1px')).toBe(1)
+    expect(toInt(null)).toBe(0)
   })
 
   test('`isString` return `true` on valid string', () => {


### PR DESCRIPTION
When configuring distance values, such as with `peek`, all options must be supplied else Glide fails to render.

This works:

```
{
    peek: {
        before: 50,
        after: 100
    }
}
```

But setting only a single property breaks:

```
{
    peek: {
        before: 50
    }
}
```

This is because `peek.after` is `NaN` which then breaks the various calculations.

My changes ensure `toInt` and `toFloat` will always return a default value of `0`, which ensures calculations continue to work.