### PR TITLE
Add support for `rem` values in gap and peek

### DIFF
--- a/src/components/gaps.js
+++ b/src/components/gaps.js
@@ -1,4 +1,4 @@
-import { toInt } from '../utils/unit'
+import { toPx } from '../utils/unit'
 import { define } from '../utils/object'
 import { throttle } from '../utils/wait'
 
@@ -58,7 +58,7 @@ export default function (Glide, Components, Events) {
      * @returns {Number}
      */
     get () {
-      return toInt(Glide.settings.gap)
+      return toPx(Glide.settings.gap)
     }
   })
 

--- a/src/components/peek.js
+++ b/src/components/peek.js
@@ -1,5 +1,5 @@
 import { define } from '../utils/object'
-import { toInt, isObject } from '../utils/unit'
+import { isObject, toPx } from '../utils/unit'
 
 export default function (Glide, Components, Events) {
   const Peek = {
@@ -31,10 +31,10 @@ export default function (Glide, Components, Events) {
      */
     set (value) {
       if (isObject(value)) {
-        value.before = toInt(value.before)
-        value.after = toInt(value.after)
+        value.before = toPx(value.before)
+        value.after = toPx(value.after)
       } else {
-        value = toInt(value)
+        value = toPx(value)
       }
 
       Peek._v = value

--- a/src/utils/unit.js
+++ b/src/utils/unit.js
@@ -21,6 +21,25 @@ export function toFloat (value) {
 }
 
 /**
+ * Converts a number or string of format /\d+(px|rem|em)?/
+ * to a number in pixel units
+ * @param {String|Number} value
+ * @param {Glide} glide
+ * @returns {Number}
+ */
+export function toPx (value) {
+  const int = toInt(value)
+  if (isNumber(value)) return int
+
+  if (value.endsWith('rem')) {
+    const { fontSize } = window.getComputedStyle(document.documentElement)
+    return toInt(int * toFloat(fontSize))
+  }
+
+  return int
+}
+
+/**
  * Indicates whether the specified value is a string.
  *
  * @param  {*}   value

--- a/tests/unit/unit.test.js
+++ b/tests/unit/unit.test.js
@@ -1,5 +1,6 @@
 import {
   toInt,
+  toPx,
   isArray,
   isString,
   isObject,
@@ -13,6 +14,13 @@ describe('Function', () => {
     expect(toInt(1, 100)).toBe(1)
     expect(toInt('1', 100)).toBe(1)
     expect(toInt('1px', 100)).toBe(1)
+  })
+
+  test('`toPx` should convert number, rem and px to pixel unit', () => {
+    document.documentElement.style.fontSize = '16px'
+    expect(toPx(1)).toBe(1)
+    expect(toPx('1px')).toBe(1)
+    expect(toPx('1rem')).toBe(16)
   })
 
   test('`isString` return `true` on valid string', () => {


### PR DESCRIPTION
This allows the use of relative sizes with `rem` in `peek` and `gap` instead of just pixel units.