### PR TITLE
Remove will-change property

### DIFF
--- a/src/assets/sass/glide.core.scss
+++ b/src/assets/sass/glide.core.scss
@@ -31,7 +31,6 @@
     white-space: nowrap;
     display: flex;
     flex-wrap: nowrap;
-    will-change: transform;
 
     &#{$glide-modifier-separator}dragging {
       user-select: none;


### PR DESCRIPTION
Including `will-change` on `.glide__slides` introduces a rendering issue
in Safari when a slide contains a video and the user tries to watch said
video in full screen. Removing this one property (or defaulting it to
`auto`) resolves the issue.

See https://codepen.io/robmaurizi-the-vuer/full/rNJpPON for an example
of the offending behavior.

This resolves https://github.com/glidejs/glide/issues/616