### PR TITLE
Add  package.json "type" field

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
   testEnvironment: 'jsdom'
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "jest tests/**/*.test.js",
     "lint": "eslint {src,tests}/**/*.js"
   },
+  "type": "module",
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.4",


### PR DESCRIPTION
This change makes Glide compatible with Node > 15

Within a package, the package.json "type" field defines how Node.js should interpret .js files. If a package.json file does not have a "type" field, .js files are treated as CommonJS.

A package.json "type" value of "module" tells Node.js to interpret .js files within that package as using ES module syntax.