### PR TITLE
Lazy Loaded Images

### DIFF
--- a/entry/entry-complete.js
+++ b/entry/entry-complete.js
@@ -17,6 +17,7 @@ import Transition from '../src/components/transition'
 // Optional components
 import Swipe from '../src/components/swipe'
 import Images from '../src/components/images'
+import Lazy from '../src/components/lazy'
 import Anchors from '../src/components/anchors'
 import Controls from '../src/components/controls'
 import Keyboard from '../src/components/keyboard'
@@ -45,7 +46,8 @@ const COMPONENTS = {
   Controls,
   Keyboard,
   Autoplay,
-  Breakpoints
+  Breakpoints,
+  Lazy
 }
 
 export default class Glide extends Core {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "@glidejs/glide",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.5.0",
+      "name": "@glidejs/glide",
+      "version": "3.6.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.16.0",

--- a/src/assets/sass/glide.core.scss
+++ b/src/assets/sass/glide.core.scss
@@ -68,4 +68,24 @@
   &#{$sm}rtl {
     direction: rtl;
   }
+
+  &__lazy__loaded {
+    -webkit-animation: fadeInFromNone 0.5s ease-in 0s forwards;
+          animation: fadeInFromNone 0.5s ease-in 0s forwards;
+  }
+}
+
+@keyframes fadeInFromNone {
+  0% {
+    visibility: hidden;
+    opacity: 0;
+  }
+  1% {
+    visibility: visible;
+    opacity: 0;
+  }
+  100% {
+    visibility: visible;
+    opacity: 1;
+  }
 }

--- a/src/components/lazy.js
+++ b/src/components/lazy.js
@@ -6,7 +6,7 @@ export default function (Glide, Components, Events) {
    *
    * @type {Object}
    */
-  let settings = Glide.settings
+  const settings = Glide.settings
   let inView = false
 
   const Lazy = {
@@ -39,8 +39,8 @@ export default function (Glide, Components, Events) {
     lazyLoad () {
       let length
       inView = true
-      if (Glide.index + 1 < this._slideElements.length) {
-        length = Glide.index + 1
+      if (Glide.index + (settings.lazyInitialSlidesLoaded - 1) < this._slideElements.length) {
+        length = Glide.index + (settings.lazyInitialSlidesLoaded - 1)
       } else {
         length = Glide.index
       }
@@ -80,7 +80,6 @@ export default function (Glide, Components, Events) {
 
   document.addEventListener('scroll', throttle(() => {
     if (settings.lazy && !inView) {
-      console.log('Scroll')
       Lazy.withinView()
     }
   }, 100))

--- a/src/components/lazy.js
+++ b/src/components/lazy.js
@@ -12,7 +12,7 @@ export default function (Glide, Components, Events) {
   const Lazy = {
     mount () {
       /**
-       * Collection of image element to be lazy loaded.
+       * Collection of slide elements
        *
        * @private
        * @type {HTMLCollection}
@@ -38,9 +38,10 @@ export default function (Glide, Components, Events) {
 
     lazyLoad () {
       let length
+      const additionSlides = settings.lazyInitialSlidesLoaded - 1
       inView = true
-      if (Glide.index + (settings.lazyInitialSlidesLoaded - 1) < this._slideElements.length) {
-        length = Glide.index + (settings.lazyInitialSlidesLoaded - 1)
+      if (Glide.index + additionSlides < this._slideElements.length) {
+        length = Glide.index + additionSlides
       } else {
         length = Glide.index
       }

--- a/src/components/lazy.js
+++ b/src/components/lazy.js
@@ -1,0 +1,63 @@
+import { throttle } from '../utils/wait'
+
+export default function (Glide, Components, Events) {
+  /**
+   * Holds reference to settings.
+   *
+   * @type {Object}
+   */
+  let settings = Glide.settings
+
+  const Lazy = {
+    mount () {
+      /**
+       * Collection of image element to be lazy loaded.
+       *
+       * @private
+       * @type {HTMLCollection}
+       */
+      if (settings.lazy) {
+        this._slideElements = Components.Html.root.querySelectorAll('.glide__slide')
+      }
+    },
+
+    lazyLoad () {
+      let length
+      if (Glide.index + 1 < this._slideElements.length) {
+        length = Glide.index + 1
+      } else {
+        length = Glide.index
+      }
+      for (let i = Glide.index; i <= length; i++) {
+        const img = this._slideElements[i].getElementsByTagName('img')[0]
+        if (img && img.classList.contains('glide__lazy')) {
+          if (!this._slideElements[i].classList.contains('glide__lazy__loaded')) {
+            this.loadImage(img)
+          }
+        }
+      }
+    },
+
+    loadImage (image) {
+      if (image.dataset.src) {
+        image.src = image.dataset.src
+        image.classList.add('glide__lazy__loaded')
+        image.classList.remove('glide__lazy')
+      }
+    }
+  }
+
+  Events.on(['mount.after'], () => {
+    if (settings.lazy) {
+      Lazy.lazyLoad()
+    }
+  })
+
+  Events.on(['move.after'], throttle(() => {
+    if (settings.lazy) {
+      Lazy.lazyLoad()
+    }
+  }, 100))
+
+  return Lazy
+}

--- a/src/components/lazy.js
+++ b/src/components/lazy.js
@@ -44,7 +44,7 @@ export default function (Glide, Components, Events) {
       } else {
         length = Glide.index
       }
-      for (let i = Glide.index; i <= length; i++) {
+      for (let i = 0; i <= length; i++) {
         const img = this._slideElements[i].getElementsByTagName('img')[0]
         if (img && img.classList.contains('glide__lazy')) {
           if (!this._slideElements[i].classList.contains('glide__lazy__loaded')) {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -198,6 +198,13 @@ export default {
   breakpoints: {},
 
   /**
+   * Enable lazy loading.
+   *
+   * @type {Boolean}
+   */
+  lazy: false,
+
+  /**
    * Collection of internally used HTML classes.
    *
    * @todo Refactor `slider` and `carousel` properties to single `type: { slider: '', carousel: '' }` object

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -205,6 +205,22 @@ export default {
   lazy: false,
 
   /**
+   * Defines the threshold in which lazy loading will begin.
+   * For example: a threshold of 1.2 will load the images if the carousel/slider
+   * is within 120% of the screen width and height
+   *
+   * @type {Number}
+   */
+  lazyScrollThreshold: 1.2,
+
+  /**
+   * Defines the inital amount of slides to be loaded
+   *
+   * @type {Number}
+   */
+  lazyInitialSlidesLoaded: 2,
+
+  /**
    * Collection of internally used HTML classes.
    *
    * @todo Refactor `slider` and `carousel` properties to single `type: { slider: '', carousel: '' }` object


### PR DESCRIPTION
Hey @jedrzejchalubek I've added lazy image loading as requested by #362

I've kept it pretty barebones in functionality as I wait to see if this is:

1. Something you even want the project to have.
2. How big in scope the lazy loading feature should be.

## Initalization

The HTML syntax for lazy loading images is as follows:

```
<div class="glide">
  <div class="glide__track" data-glide-el="track">
    <ul class="glide__slides">
      <li class="glide__slide"><img class='glide__lazy' data-src="IMAGE_URL"></li>
      <li class="glide__slide"><img class='glide__lazy' data-src="IMAGE_URL"></li>
      <li class="glide__slide"><img class='glide__lazy' data-src="IMAGE_URL"></li>
    </ul>
  </div>
</div>
```

To initialize lazy loading the default `lazy` must be set to true, by default it is false.

`new Glide('#glide', { lazy: true }).mount()`


***

## Additional defaults

- `lazyInitialSlidesLoaded`
Defines the initial amount of slides to be loaded

- `lazyScrollThreshold`
Defines the threshold in which lazy loading will begin. For example, a threshold of 1.2 will load the images if the carousel/slider is within 120% of the screen width and height


Let me know what you think, happy to amend PR further if necessary.