### PR TITLE
Resolve issue #523

### DIFF
--- a/src/components/html.js
+++ b/src/components/html.js
@@ -48,7 +48,7 @@ export default function (Glide, Components, Events) {
         r = document.querySelector(r)
       }
 
-      if (exist(r)) {
+      if (r !== null) {
         Html._r = r
       } else {
         warn('Root element must be a existing Html node')


### PR DESCRIPTION
There is no point at checking the constructor name of the node instance. Either it is null - because the query selector did not find any DOM element or null was passed as parameter - or it is valid.