### PR TITLE
Fix issue #523 - "Slider cannot be initialized in iframe"

### DIFF
--- a/src/components/html.js
+++ b/src/components/html.js
@@ -48,7 +48,7 @@ export default function (Glide, Components, Events) {
         r = document.querySelector(r)
       }
 
-      if (r !== null) {
+      if (exist(r)) {
         Html._r = r
       } else {
         warn('Root element must be a existing Html node')

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -28,7 +28,8 @@ export function siblings (node) {
  * @return {Boolean}
  */
 export function exist (node) {
-  if (node && node instanceof window.HTMLElement) {
+  // We are usine duck-typing here because we can't use `instanceof` since if we're in an iframe the class instance will be different.
+  if (node && node.appendChild && node.isConnected) {
     return true
   }
 


### PR DESCRIPTION
# How to recreate the issue
Load glide in an iframe

# What I Did
I changed the `exist()` method to use duck-typing instead of a `null` check.  

The work that @ericmorand did in pull request #669 did not fully solve the problem, and also sort of makes it possible to pass invalid objects, so was not a preferred solution. Thanks for leading me in the right direction though @ericmorand!

# How was it tested
Loaded in iframe and out of iframe.