### PR TITLE
fix: check if HTMLElement is valid in iframe or window

### DIFF
--- a/src/components/html.js
+++ b/src/components/html.js
@@ -48,7 +48,7 @@ export default function (Glide, Components, Events) {
         r = document.querySelector(r)
       }
 
-      if (r !== null) {
+      if (exist(r)) {
         Html._r = r
       } else {
         warn('Root element must be a existing Html node')

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -28,7 +28,7 @@ export function siblings (node) {
  * @return {Boolean}
  */
 export function exist (node) {
-  if (node && node instanceof (node.ownerDocument.defaultView || window).HTMLElement) {
+  if (node && node instanceof (node.ownerDocument?.defaultView || window).HTMLElement) {
     return true
   }
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -28,7 +28,7 @@ export function siblings (node) {
  * @return {Boolean}
  */
 export function exist (node) {
-  if (node && node instanceof window.HTMLElement) {
+  if (node && node instanceof (node.ownerDocument.defaultView || window).HTMLElement) {
     return true
   }
 


### PR DESCRIPTION
There was a fix that was introduced in PR #669, however it didn't fully fix the issue as there were other elements which checked for the validity of a HTML element without using query selector.

This PR reverts back to the use of the original `exist()` function but checks to see whether the element exists in the iframe window or within the main window