### PR TITLE
- Remove "exists" check of the glide track element

### DIFF
--- a/src/components/html.js
+++ b/src/components/html.js
@@ -72,11 +72,7 @@ export default function (Glide, Components, Events) {
      * @return {Object}
      */
     set (t) {
-      if (exist(t)) {
         Html._t = t
-      } else {
-        warn(`Could not find track element. Please use ${TRACK_SELECTOR} attribute.`)
-      }
     }
   })
 


### PR DESCRIPTION
As requested in #694 this MR remove the exists check that was causing problems when using slides inside an iframe in Firefox.