### PR TITLE
fix: add specifier in package.json to expose all files in `./dist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
       "import": "./dist/glide.esm.js",
       "require": "./dist/glide.js",
       "default": "./dist/glide.esm.js"
-    }
+    },
+    "./dist/*": "./dist/*"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
Possibly fixes #700, #701 so that `import "@glidejs/glide/css/glide.core.css"` for example works again

Note that this is NOT TESTED. It seems legit that `"./dist/*": "./dist/*"` does expose all files in dist, but I have not personally tested that it works.