### PR TITLE
fix: add specifier in package.json to expose all files in ./src

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
       "require": "./dist/glide.js",
       "default": "./dist/glide.esm.js"
     },
-    "./dist/*": "./dist/*"
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
Fixes #701. This makes the import "@glidejs/glide/css/glide.core.css" works again.